### PR TITLE
Addition of install.sh required for comrade package manager installation

### DIFF
--- a/install.sh
+++ b/install.sh
@@ -1,0 +1,2 @@
+cargo build --release
+cp target/release/pravda .


### PR DESCRIPTION
**Added install.sh required for installation from comrade package manager.**
This will allow you to install this program using comrade.
I would be happy to approve this pull request!